### PR TITLE
renovate: add llama.cpp build-number versioning override

### DIFF
--- a/.renovate/overrides.json5
+++ b/.renovate/overrides.json5
@@ -16,6 +16,12 @@
              matchDatasources: ["docker"],
              matchPackageNames: ["ghcr.io/mogenius/helm-charts/renovate-operator"],
              sourceUrl: "https://github.com/mogenius/renovate-operator",
-        }
+        },
+        {
+            description: "llama.cpp uses build-number tags with variant prefix",
+            matchDatasources: ["docker"],
+            matchPackageNames: ["ghcr.io/ggml-org/llama.cpp"],
+            versioning: "regex:^server-intel-b(?<patch>\\d+)$",
+        },
     ],
 }


### PR DESCRIPTION
## Summary
- Adds a `packageRules` entry for `ghcr.io/ggml-org/llama.cpp` so Renovate can track the `server-intel-b<N>` tag scheme used by `kubernetes/apps/ai/llama-cpp` (in [mediaserver](https://github.com/eleboucher/mediaserver)).
- Uses `versioning: regex:^server-intel-b(?<patch>\d+)$` — the regex both pins the variant (so `server-cuda-*`, `full-intel-*` etc. are excluded) and provides numeric ordering on the build number.

## Test plan
- [ ] Renovate dependency dashboard shows the next `server-intel-bN` tag for llama-cpp
- [ ] No update PRs targeting wrong variants (cuda/vulkan/musa)