### PR TITLE
fix(vmalert): evaluate PrometheusRules in every namespace

### DIFF
--- a/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
@@ -224,6 +224,10 @@ spec:
     vmalert:
       spec:
         evaluationInterval: 30s
+        # {} = all namespaces: without this the operator restricts vmalert to
+        # its own namespace and PrometheusRules elsewhere (miroir, cnpg,
+        # cert-manager, network, ...) are silently never evaluated.
+        ruleNamespaceSelector: {}
         ruleSelector:
           matchExpressions:
             - key: vmalert-datasource


### PR DESCRIPTION
vmalert had \`ruleSelector\` but no \`ruleNamespaceSelector\`; the victoria-metrics operator defaults that to vmalert's own namespace. Result: converted PrometheusRules outside \`observability\` (miroir, cnpg, cert-manager, flux-system, network, kopiur, system-upgrade) were silently never evaluated — e.g. miroir's \`MiroirVolumeSuspendedBarrier\` never fired during a 7h stranded-barrier freeze.

Adding \`ruleNamespaceSelector: {}\` (all namespaces) also loads those other namespaces' rules for the first time — a wave of newly-firing alerts is possible.